### PR TITLE
Add a new property

### DIFF
--- a/buildah.properties
+++ b/buildah.properties
@@ -7,3 +7,4 @@ registry.perftest.context=./context
 registry.perftest.registryUrl=docker.io/jeremyspykerman
 registry.perftest.image=perftest
 registry.perftest.toolExe=buildah
+registry.perftest.registryAuthFile=/etc/registry_auth/auth.json

--- a/container-registry-performance-test.jmx
+++ b/container-registry-performance-test.jmx
@@ -48,6 +48,11 @@
             <stringProp name="Argument.value">${__P(registry.perftest.toolExe)}</stringProp>
             <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="registryAuthFile" elementType="Argument">
+            <stringProp name="Argument.name">registryAuthFile</stringProp>
+            <stringProp name="Argument.value">${__P(registry.perftest.registryAuthFile)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </elementProp>
       <stringProp name="TestPlan.user_define_classpath"></stringProp>
@@ -177,7 +182,13 @@
             </collectionProp>
           </elementProp>
           <elementProp name="SystemSampler.environment" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
-            <collectionProp name="Arguments.arguments"/>
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="REGISTRY_AUTH_FILE" elementType="Argument">
+                <stringProp name="Argument.name">REGISTRY_AUTH_FILE</stringProp>
+                <stringProp name="Argument.value">${registryAuthFile}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
           </elementProp>
           <stringProp name="SystemSampler.directory">${dockerContext}</stringProp>
           <stringProp name="SystemSampler.stdout">./testlogs/main_push_${megabytes}_${i}_stdout.log</stringProp>

--- a/docker.properties
+++ b/docker.properties
@@ -7,3 +7,4 @@ registry.perftest.context=./context
 registry.perftest.registryUrl=docker.io/jeremyspykerman
 registry.perftest.image=perftest
 registry.perftest.toolExe=docker
+registry.perftest.registryAuthFile=""

--- a/run_test.sh
+++ b/run_test.sh
@@ -2,4 +2,4 @@
 
 mkdir -p testlogs results
 
-./jmeter/apache-jmeter-5.5/bin/jmeter -t container-registry-performance-test.jmx -p perftest.properties -n
+./jmeter/apache-jmeter-5.5/bin/jmeter -t container-registry-performance-test.jmx -p docker.properties -n


### PR DESCRIPTION
When using buildah, it is nice to set the authentication without needing interaction. Passing in a new property to accomodate setting that environment variable facilitates working non-interactively with buildah.