### PR TITLE
Use jmeter from path

### DIFF
--- a/fetch_jmeter.sh
+++ b/fetch_jmeter.sh
@@ -1,6 +1,9 @@
 #!/bin/sh -e
 #
 # download, extract and prepare jmeter for use with this repository
+# this downloads and prepares jmeter, but does not put it into your
+# path. Be sure to add jmeter/apache-jmeter-${JMETER_VERSION}/bin
+# to your path if you want the run script to function correctly
 
 JMETER_HOME=jmeter
 JMETER_VERSION="5.5"

--- a/run_test.sh
+++ b/run_test.sh
@@ -12,4 +12,4 @@ if [ "$#" -ne "1" ]; then
     exit -1
 fi
 
-./jmeter/apache-jmeter-5.5/bin/jmeter -t container-registry-performance-test.jmx -p "$1" -J registry.perftest.registryRestPassword=${REGISTRY_PASSWORD} -J registry.perftest.registryRestUsername=${REGISTRY_USERNAME} -n
+jmeter -t container-registry-performance-test.jmx -p "$1" -J registry.perftest.registryRestPassword=${REGISTRY_PASSWORD} -J registry.perftest.registryRestUsername=${REGISTRY_USERNAME} -n


### PR DESCRIPTION
Having a specific path relative to the project where we expect to find the jmeter binary is a bit restrictive.

If we simply use the path to resolve the jmeter binary, there is much more flexibility for deployment options.