### PR TITLE
Make curl exit with failure for unsuccessful status codes

### DIFF
--- a/delete_remote_image.sh
+++ b/delete_remote_image.sh
@@ -98,4 +98,4 @@ item_url="${baseurl}/${organisation}/${image}/${tag}/"
 
 echo "deleting item ${item_url}"
 
-curl -L -u "${REGISTRY_USERNAME}:${REGISTRY_PASSWORD}" -X DELETE "${item_url}"
+curl -f -L -u "${REGISTRY_USERNAME}:${REGISTRY_PASSWORD}" -X DELETE "${item_url}"


### PR DESCRIPTION
By default, curl does not exit with a failure code if the server returns an error code. The `-f` option will be more helpful in our use case.